### PR TITLE
Notify widget running task via hub

### DIFF
--- a/component/widget.js
+++ b/component/widget.js
@@ -144,6 +144,8 @@ define([ "troopjs-core/component/gadget", "jquery", "../loom/config", "../loom/w
 
 		"sig/task" : function onTask(task) {
 			this[$ELEMENT].trigger("task", [ task ]);
+			// Notify any running task, e.g. used for UI spinning.
+			this.publish("task", task, this);
 		},
 
 		/**


### PR DESCRIPTION
Currently we rely on DOM event "task" that bubbles up the widget tree to notify a running task inside of the widget, the limitation of this approach is when widget lives on a high level DOM element, like document/window, it's hard to get all UI widgets notified.

The typical case for this scenario is a spinner widget hooked in somewhere in the page, is unable to get notified when the mvc controller widget(which is hooked onto window) is querying for data.

In additional to the DOM event, a hub event would be the idea candidate for this job.
