### PR TITLE
Weaving all widgets before application start

### DIFF
--- a/application/widget.js
+++ b/application/widget.js
@@ -64,8 +64,9 @@ define([ "module", "../component/widget", "when", "troopjs-core/registry/service
 			var weave = me.weave;
 			var args = arguments;
 
-			return forward.call(me, "start", args).then(function started() {
-				return weave.apply(me, args);
+			// Widgets like spinner and error handler, need to be woven before starting any service.
+			return weave.apply(me, args).then(function () {
+				return forward.call(me, "start", args);
 			});
 		},
 


### PR DESCRIPTION
The order we currently impose on page load (the application widget) is like:
1. start all registered services;
2. weaving all page widgets.

Generally application start logic involves starting multiple services that might need to talk to the server, while page widgets are likely to include error handling, spinning and logging component that requires presence at the very beginning, other UI widgets are  likely to be relatively lazy components that waiting for hub events, it would make sense to **reverse** the current bootstrap order, having widgets instantiated as the first stage before services.
