### PR TITLE
Async template updates

### DIFF
--- a/component/widget.js
+++ b/component/widget.js
@@ -60,8 +60,9 @@ define([
 			var me = this;
 
 			// Retrieve HTML/Text.
-			if (!arguments.length)
+			if (!arguments.length) {
 				return $fn.call(me[$ELEMENT]);
+			}
 
 			return when
 				// Wait for contents and args to resolve...

--- a/test/component/widget-test.js
+++ b/test/component/widget-test.js
@@ -189,28 +189,28 @@ buster.testCase("troopjs-browser/component/widget", function (run) {
 				"render proxy - html": function() {
 					var me = this;
 
-					return weave.call(me.$el.filter('.foo')).spread(function(widgets) {
+					return weave.call(me.$el.filter(".foo")).spread(function(widgets) {
 						var widget = widgets[0];
 						function assertContent(expected) {
 							assert.same(expected, widget.html());
 						}
-						return widget.html('foo').then(function() {
-							assertContent('foo');
+						return widget.html("foo").then(function() {
+							assertContent("foo");
 						}).then(function() {
-							return widget.html(when('foo')).then(function() {
-								assertContent('foo');
+							return widget.html(when("foo")).then(function() {
+								assertContent("foo");
 							});
 						}).then(function() {
 							return widget.html(function(val) {
 								return when(val);
-							}, 'foo').then(function() {
-								assertContent('foo');
+							}, "foo").then(function() {
+								assertContent("foo");
 							});
 						}).then(function() {
 							return widget.html(when(function(val) {
 								return when(val);
-							}), 'foo').then(function() {
-								assertContent('foo');
+							}), "foo").then(function() {
+								assertContent("foo");
 							});
 						});
 					});


### PR DESCRIPTION
Allow either/all of:
- contents (template)
- args (template parameters)
- result from a template

to be promises.

---

So I've tested this locally and it looks fine, but before we merge we should add tests for:
- [ ] `.html(String)`
- [ ] `.html(Promise{String})`
- [ ] `.html(Function, Object)`
- [ ] `.html(Function, Promise{Object})`
- [ ] `.html(Promise{Function}, Object)`
- [ ] `.html(Promise{Function}, Promise{Object})`
- [ ] `.html(Function{return: Promise{String}}, Object)`
