### PR TITLE
render result resolution

### DIFF
--- a/component.js
+++ b/component.js
@@ -303,29 +303,35 @@ define([
 			}
 
 			// Slice `arguments` to `args`
-			var args = ARRAY_SLICE.call(arguments, 1);
+			var args = ARRAY_SLICE.call(arguments, 0);
 
 			return when(contentOrPromise, function (content) {
 				// If `content` is a function ...
 				return (OBJECT_TOSTRING.call(content) === TOSTRING_FUNCTION)
-					// ... return result of applying `content` ...
-					? content.apply(me, args)
+					// ... return result of applying `content` with sliced `args`...
+					? content.apply(me, ARRAY_SLICE.call(args, 1))
 					// ... otherwise return `content`
 					: content;
 			})
-				.tap(function (content) {
-					var _args;
+				.then(function (content) {
+					// Let `args[0]` be `$(content)`
+					// Let `$content` be `args[0]`
+					var $content = args[0] = $(content);
 
-					// Let `args[0]` be `content`
-					// Call `$fn` with `content`
-					$fn.call(me[$ELEMENT], content);
+					// Let `emit_args` be `[ SIG_RENDER ]`
+					var emit_args = [ SIG_RENDER ];
 
-					// Let `_args` be `[ SIG_RENDER, content ]`
-					// Push `args` on `_args`
-					ARRAY_PUSH.apply(_args = [ SIG_RENDER, content ], args);
+					// Push `args` on `emit_args`
+					ARRAY_PUSH.apply(emit_args, args);
 
-					// Signal render
-					return me.emit.apply(me, _args);
+					// Call `$fn` with `$content`
+					$fn.call(me[$ELEMENT], $content);
+
+					// Emit `emit_args`
+					// Yield `args`
+					return me.emit
+						.apply(me, emit_args)
+						.yield(args);
 				});
 		};
 

--- a/test/component-test.js
+++ b/test/component-test.js
@@ -155,6 +155,20 @@ define([
 			}
 		},
 
+		"render": {
+			"html": function () {
+				return Component($("<div>"))
+					.html("THIS IS HTML", 1, 2, 3)
+					.then(function (args) {
+						assert.equals(args.length, 4);
+						assert.isObject(args[0]);
+						assert.equals(args[1], 1);
+						assert.equals(args[2], 2);
+						assert.equals(args[3], 3);
+					});
+			}
+		},
+
 		"tearDown": function () {
 			this.$el.remove();
 		}


### PR DESCRIPTION
At the moment the render functions (`html`, `text`, `before`, `after`, `append` and `prepend`) return a `Promise` that resolves to a `String` value. This patch changes that to resolve to a the original `arguments` with the first argument replaced by the created `jQuery` object.