### PR TITLE
Change scope of template execution from component to $element.

### DIFF
--- a/component.js
+++ b/component.js
@@ -88,8 +88,8 @@ define([
 				_args[_length - 1] = args[_length];
 			}
 
-			// Return result of applying `content` on `me` with `_args`
-			return content.apply(me, _args);
+			// Return result of applying `content` on `$element` with `_args`
+			return content.apply($element, _args);
 		})
 		.then(function (content) {
 			// Let `args[0]` be `$(content)`


### PR DESCRIPTION
* It's probably not a good idea to leak the full component to templates (from a security POV).
* Since 37d50b8002f08fe4fd3e4bf9ceecb238dd2a6959 we've added `appendTo` and `prependTo`. Before this a template could get a hold of the element via `this.$element`, that's not possible anymore.